### PR TITLE
redirect stderr to /dev/null during build.

### DIFF
--- a/modules/faas/Makefile
+++ b/modules/faas/Makefile
@@ -6,7 +6,7 @@ $(FAAS_BUILD_DIST):
 	mkdir -p $(FAAS_BUILD_DIST)
 
 $(FAAS_BUILD_VENV):
-	$(WITH_PIPENV) pip install -r <(pipenv lock -r) --target $(FAAS_BUILD_VENV) --ignore-installed
+	$(WITH_PIPENV) pip install -r <(pipenv lock -r 2> /dev/null) --target $(FAAS_BUILD_VENV) --ignore-installed
 	find -L . -path $(FAAS_BUILD_VENV) -prune -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 	find -L $(FAAS_BUILD_VENV) -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 

--- a/modules/faas/Makefile
+++ b/modules/faas/Makefile
@@ -6,7 +6,7 @@ $(FAAS_BUILD_DIST):
 	mkdir -p $(FAAS_BUILD_DIST)
 
 $(FAAS_BUILD_VENV):
-	$(WITH_PIPENV) pip install -r <(pipenv lock -r 2> /dev/null) --target $(FAAS_BUILD_VENV) --ignore-installed
+	$(WITH_PIPENV) pip install -r <(PIPENV_QUIET=1 pipenv --bare lock -r) --target $(FAAS_BUILD_VENV) --ignore-installed
 	find -L . -path $(FAAS_BUILD_VENV) -prune -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 	find -L $(FAAS_BUILD_VENV) -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 


### PR DESCRIPTION
Jenkins has a hard time building because the "Running..." message gets put into the -r requirements arg.
example: https://jenkins.everest-shared.aws.mintel.com/blue/organizations/jenkins/lam_product_tagger_collector/detail/master/174/pipeline/

This silences the "Running..." message and everything else until the requirements list is properly generated.