### PR TITLE
PIPENV_QUIET doesn't work like we thought

### DIFF
--- a/modules/django/Makefile
+++ b/modules/django/Makefile
@@ -1,7 +1,12 @@
 ## Run Django tests
 django/test: pipenv
 	$(WITH_PIPENV) ./manage.py migrate
-	$(WITH_PIPENV) ./manage.py test
+	$(WITH_PIPENV) ./manage.py test -- -m "not postbuild"
+
+## Run Django tests
+django/test-post-build: pipenv
+	$(WITH_PIPENV) ./manage.py migrate
+	$(WITH_PIPENV) ./manage.py test -- -m "postbuild"
 
 ## Run Django check
 django/check: pipenv

--- a/modules/faas/Makefile
+++ b/modules/faas/Makefile
@@ -6,7 +6,7 @@ $(FAAS_BUILD_DIST):
 	mkdir -p $(FAAS_BUILD_DIST)
 
 $(FAAS_BUILD_VENV):
-	$(WITH_PIPENV) pip install -r <(PIPENV_QUIET=1 pipenv --bare lock -r) --target $(FAAS_BUILD_VENV) --ignore-installed
+	$(WITH_PIPENV) pip install -r <(pipenv lock -r 2> /dev/null) --target $(FAAS_BUILD_VENV) --ignore-installed
 	find -L . -path $(FAAS_BUILD_VENV) -prune -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 	find -L $(FAAS_BUILD_VENV) -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 


### PR DESCRIPTION
PIPENV_QUEIT and --bare doesn't silence pipenv

example:
https://jenkins.everest-shared.aws.mintel.com/blue/organizations/jenkins/lam_product_entry_discovery/detail/master/24/pipeline