### PR TITLE
Add ability to set dev compose file which will be used additionally

### DIFF
--- a/modules/compose/Makefile
+++ b/modules/compose/Makefile
@@ -3,7 +3,12 @@ DOCKER_MONITOR_TABLE ?= 'table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t
 
 SHELL_UID := $(shell ls -id . | cut -d' ' -f1)_$(shell id -u)
 
-export COMPOSE_FILE ?= docker/docker-compose.yaml
+export COMPOSE_FILE?=docker/docker-compose.yaml
+export COMPOSE_DEV_FILE?=
+COMPOSE_FILE_ARGS=-f $(COMPOSE_FILE) -f $(COMPOSE_DEV_FILE)
+ifndef COMPOSE_DEV_FILE
+	COMPOSE_FILE_ARGS=-f $(COMPOSE_FILE)
+endif
 
 $(COMPOSE_FILE):
 	@echo "Compose file not found! ($(COMPOSE_FILE))"
@@ -12,46 +17,47 @@ $(COMPOSE_FILE):
 compose/debug: $(COMPOSE_FILE)
 	@echo "SERVICE_NAME=$(SERVICE_NAME)"
 	@echo "COMPOSE_FILE=$(COMPOSE_FILE)"
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) --version
+	@echo "COMPOSE_DEV_FILE=$(COMPOSE_DEV_FILE)"
+	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) --version
 
 ## Start local dev environment (daemonized)
 compose/up: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) up -d
+	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) up -d
 
 ## Stop local dev environment
 compose/down: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) down
+	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) down
 
 ## Restart local dev environment
 compose/restart: compose/down compose/up
 
 ## Purge local dev environment
 compose/purge: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) down -v
+	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) down -v
 
 ## Rebuild custom containers for local dev environment
 compose/rebuild: compose/down compose/build compose/up
 
 ## Tail logs from docker-compose containers
 compose/logs: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) logs -f
+	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) logs -f
 
 ## Build local dev environment
 compose/build: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) build
+	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) build
 
 ## Show default compose ps
 compose/ps: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) ps
+	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) ps
 
 ## Show containers resource usage
 compose/monitor: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
+	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
 
 ## Monitor in time containers resource usage
 compose/monitor/follow: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
+	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
 
 ## Show top for containers
 compose/top: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" -f $(COMPOSE_FILE) top
+	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) top

--- a/modules/compose/Makefile
+++ b/modules/compose/Makefile
@@ -15,9 +15,10 @@ $(COMPOSE_FILE):
 	@exit 1
 
 compose/debug: $(COMPOSE_FILE)
+	@echo "SHELL_UID=$(SHELL_UID)"
 	@echo "COMPOSE_SERVICE_NAME=$(COMPOSE_SERVICE_NAME)"
-	@echo "COMPOSE_FILE=$(COMPOSE_FILE)"
-	@echo "COMPOSE_DEV_FILE=$(COMPOSE_DEV_FILE)"
+	@echo "COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME)"
+	@echo "COMPOSE_FLAGS=$(COMPOSE_FLAGS)"
 	$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) --version
 
 ## Start local dev environment (daemonized)

--- a/modules/compose/Makefile
+++ b/modules/compose/Makefile
@@ -2,6 +2,7 @@ DOCKER_COMPOSE = $(shell which docker-compose)
 DOCKER_MONITOR_TABLE ?= 'table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}'
 
 SHELL_UID := $(shell ls -id . | cut -d' ' -f1)_$(shell id -u)
+export COMPOSE_SERVICE_NAME?=svc
 
 export COMPOSE_FILE?=docker/docker-compose.yaml
 export COMPOSE_DEV_FILE?=
@@ -10,54 +11,56 @@ ifndef COMPOSE_DEV_FILE
 	COMPOSE_FILE_ARGS=-f $(COMPOSE_FILE)
 endif
 
+COMPOSE_PROJECT_NAME:=$(COMPOSE_SERVICE_NAME)_$(SHELL_UID)
+
 $(COMPOSE_FILE):
 	@echo "Compose file not found! ($(COMPOSE_FILE))"
 	@exit 1
 
 compose/debug: $(COMPOSE_FILE)
-	@echo "SERVICE_NAME=$(SERVICE_NAME)"
+	@echo "COMPOSE_SERVICE_NAME=$(COMPOSE_SERVICE_NAME)"
 	@echo "COMPOSE_FILE=$(COMPOSE_FILE)"
 	@echo "COMPOSE_DEV_FILE=$(COMPOSE_DEV_FILE)"
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) --version
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) --version
 
 ## Start local dev environment (daemonized)
 compose/up: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) up -d
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) up -d
 
 ## Stop local dev environment
 compose/down: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) down
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) down
 
 ## Restart local dev environment
 compose/restart: compose/down compose/up
 
 ## Purge local dev environment
 compose/purge: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) down -v
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) down -v
 
 ## Rebuild custom containers for local dev environment
 compose/rebuild: compose/down compose/build compose/up
 
 ## Tail logs from docker-compose containers
 compose/logs: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) logs -f
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) logs -f
 
 ## Build local dev environment
 compose/build: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) build
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) build
 
 ## Show default compose ps
 compose/ps: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) ps
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) ps
 
 ## Show containers resource usage
 compose/monitor: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
 
 ## Monitor in time containers resource usage
 compose/monitor/follow: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
 
 ## Show top for containers
 compose/top: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p "$(SERVICE_NAME)_$(SHELL_UID)" $(COMPOSE_FILE_ARGS) top
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) top

--- a/modules/compose/Makefile
+++ b/modules/compose/Makefile
@@ -7,8 +7,8 @@ export COMPOSE_SERVICE_NAME?=svc
 export COMPOSE_FILE?=docker/docker-compose.yaml
 export COMPOSE_FLAGS?=
 
-COMPOSE_FLAGS:=-f $(COMPOSE_FILE) $(COMPOSE_FLAGS)
 COMPOSE_PROJECT_NAME:=$(COMPOSE_SERVICE_NAME)_$(SHELL_UID)
+COMPOSE_FLAGS:=-p $(COMPOSE_PROJECT_NAME) -f $(COMPOSE_FILE) $(COMPOSE_FLAGS)
 
 $(COMPOSE_FILE):
 	@echo "Compose file not found! ($(COMPOSE_FILE))"
@@ -18,46 +18,46 @@ compose/debug: $(COMPOSE_FILE)
 	@echo "COMPOSE_SERVICE_NAME=$(COMPOSE_SERVICE_NAME)"
 	@echo "COMPOSE_FILE=$(COMPOSE_FILE)"
 	@echo "COMPOSE_DEV_FILE=$(COMPOSE_DEV_FILE)"
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) --version
+	$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) --version
 
 ## Start local dev environment (daemonized)
 compose/up: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) up -d
+	$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) up -d
 
 ## Stop local dev environment
 compose/down: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) down
+	$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) down
 
 ## Restart local dev environment
 compose/restart: compose/down compose/up
 
 ## Purge local dev environment
 compose/purge: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) down -v
+	$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) down -v
 
 ## Rebuild custom containers for local dev environment
 compose/rebuild: compose/down compose/build compose/up
 
 ## Tail logs from docker-compose containers
 compose/logs: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) logs -f
+	@$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) logs -f
 
 ## Build local dev environment
 compose/build: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) build
+	$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) build
 
 ## Show default compose ps
 compose/ps: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) ps
+	@$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) ps
 
 ## Show containers resource usage
 compose/monitor: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
+	@$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
 
 ## Monitor in time containers resource usage
 compose/monitor/follow: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
+	@$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
 
 ## Show top for containers
 compose/top: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) top
+	@$(DOCKER_COMPOSE) $(COMPOSE_FLAGS) top

--- a/modules/compose/Makefile
+++ b/modules/compose/Makefile
@@ -5,12 +5,9 @@ SHELL_UID := $(shell ls -id . | cut -d' ' -f1)_$(shell id -u)
 export COMPOSE_SERVICE_NAME?=svc
 
 export COMPOSE_FILE?=docker/docker-compose.yaml
-export COMPOSE_DEV_FILE?=
-COMPOSE_FILE_ARGS=-f $(COMPOSE_FILE) -f $(COMPOSE_DEV_FILE)
-ifndef COMPOSE_DEV_FILE
-	COMPOSE_FILE_ARGS=-f $(COMPOSE_FILE)
-endif
+export COMPOSE_FLAGS?=
 
+COMPOSE_FLAGS:=-f $(COMPOSE_FILE) $(COMPOSE_FLAGS)
 COMPOSE_PROJECT_NAME:=$(COMPOSE_SERVICE_NAME)_$(SHELL_UID)
 
 $(COMPOSE_FILE):
@@ -21,46 +18,46 @@ compose/debug: $(COMPOSE_FILE)
 	@echo "COMPOSE_SERVICE_NAME=$(COMPOSE_SERVICE_NAME)"
 	@echo "COMPOSE_FILE=$(COMPOSE_FILE)"
 	@echo "COMPOSE_DEV_FILE=$(COMPOSE_DEV_FILE)"
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) --version
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) --version
 
 ## Start local dev environment (daemonized)
 compose/up: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) up -d
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) up -d
 
 ## Stop local dev environment
 compose/down: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) down
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) down
 
 ## Restart local dev environment
 compose/restart: compose/down compose/up
 
 ## Purge local dev environment
 compose/purge: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) down -v
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) down -v
 
 ## Rebuild custom containers for local dev environment
 compose/rebuild: compose/down compose/build compose/up
 
 ## Tail logs from docker-compose containers
 compose/logs: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) logs -f
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) logs -f
 
 ## Build local dev environment
 compose/build: $(COMPOSE_FILE)
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) build
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) build
 
 ## Show default compose ps
 compose/ps: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) ps
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) ps
 
 ## Show containers resource usage
 compose/monitor: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE) --no-stream
 
 ## Monitor in time containers resource usage
 compose/monitor/follow: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) ps -q | tr '\n' ' ' | docker stats --format $(DOCKER_MONITOR_TABLE)
 
 ## Show top for containers
 compose/top: $(COMPOSE_FILE)
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FILE_ARGS) top
+	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT_NAME) $(COMPOSE_FLAGS) top

--- a/modules/compose/Makefile
+++ b/modules/compose/Makefile
@@ -3,10 +3,8 @@ DOCKER_MONITOR_TABLE ?= 'table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t
 
 SHELL_UID := $(shell ls -id . | cut -d' ' -f1)_$(shell id -u)
 export COMPOSE_SERVICE_NAME?=svc
-
 export COMPOSE_FILE?=docker/docker-compose.yaml
 export COMPOSE_FLAGS?=
-
 COMPOSE_PROJECT_NAME:=$(COMPOSE_SERVICE_NAME)_$(SHELL_UID)
 COMPOSE_FLAGS:=-p $(COMPOSE_PROJECT_NAME) -f $(COMPOSE_FILE) $(COMPOSE_FLAGS)
 


### PR DESCRIPTION
For example, you can now do this in your makefile
```
export COMPOSE_SERVICE_NAME=workflow
export COMPOSE_FLAGS?=-f docker/docker-compose.dev.yaml

-include $(shell curl -sSL -o .build-harness "https://raw.githubusercontent.com/mintel/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
```