### PR TITLE
Refactor Python venv and dist handling

### DIFF
--- a/modules/django/Makefile
+++ b/modules/django/Makefile
@@ -1,8 +1,8 @@
 ## Run Django tests
 django/test: pipenv
-	$(WITH_PIPENV) ./manage.py migrate
-	$(WITH_PIPENV) ./manage.py test
+	$(PIPENV_RUN) ./manage.py migrate
+	$(PIPENV_RUN) ./manage.py test
 
 ## Run Django check
 django/check: pipenv
-	DJANGO_SECRET_KEY=foobar $(WITH_PIPENV) ./manage.py check
+	DJANGO_SECRET_KEY=foobar $(PIPENV_RUN) ./manage.py check

--- a/modules/faas/Makefile
+++ b/modules/faas/Makefile
@@ -9,7 +9,7 @@ $(FAAS_BUILD_DIST):
 # PYTHON
 # - - - - - - - -
 $(FAAS_BUILD_PYTHON_VENV):
-	$(WITH_PIPENV) pip install -r <(PIPENV_QUIET=1 pipenv --bare lock -r) --ignore-installed --target $(FAAS_BUILD_PYTHON_VENV)
+	$(PIPENV_RUN) pip install -r <(PIPENV_QUIET=1 pipenv --bare lock -r) --ignore-installed --target $(FAAS_BUILD_PYTHON_VENV)
 	find -L . -path $(FAAS_BUILD_PYTHON_VENV) -prune -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 	find -L $(FAAS_BUILD_PYTHON_VENV) -exec touch -d "$(FAAS_MAGIC_DATE)" {} +
 

--- a/modules/pytest/Makefile
+++ b/modules/pytest/Makefile
@@ -2,13 +2,13 @@ pytest: pytest/test
 .PHONY: pytest
 
 pytest/test: pipenv reports/
-	$(WITH_PIPENV) pytest -m "not postbuild"
+	$(PIPENV_RUN) pytest -m "not postbuild"
 .PHONY: pytest/test
 
 pytest/test-lf: pipenv reports/
-	$(WITH_PIPENV) pytest -m "not postbuild" --lf
+	$(PIPENV_RUN) pytest -m "not postbuild" --lf
 .PHONY: pytest/test-lf
 
 pytest/test-post-build: pipenv reports/
-	$(WITH_PIPENV) pytest -m postbuild
+	$(PIPENV_RUN) pytest -m postbuild
 .PHONY: pytest/test-post-build

--- a/modules/python/Makefile.dist
+++ b/modules/python/Makefile.dist
@@ -7,13 +7,13 @@ python/dist: python/dist/src python/dist/wheel
 .PHONY: python/dist/src
 ## Build Python package source distribution.
 python/dist/src: pipenv setup.py requirements.txt requirements-dev.txt
-	$(WITH_PIPENV) python setup.py sdist --dist-dir $(PYTHON_DIST_DIR)
+	$(PIPENV_RUN) python setup.py sdist --dist-dir $(PYTHON_DIST_DIR)
 
 .PHONY: python/dist/wheel
 ## Build Python package wheel distributions.
 python/dist/wheel: pipenv setup.py requirements.txt requirements-dev.txt
-	$(WITH_PIPENV) pip install -q --disable-pip-version-check wheel
-	$(WITH_PIPENV) python setup.py bdist_wheel --dist-dir $(PYTHON_DIST_DIR)
+	$(PIPENV_RUN) pip install -q --disable-pip-version-check wheel
+	$(PIPENV_RUN) python setup.py bdist_wheel --dist-dir $(PYTHON_DIST_DIR)
 
 .PHONY: python/distif
 ## Build Python package source and wheel distributions if they don't exist.

--- a/modules/python/Makefile.dist
+++ b/modules/python/Makefile.dist
@@ -4,6 +4,9 @@ PYTHON_DIST_DIR?=dist
 python/dist: pipenv setup.py pipenv/generate_requirements
 	$(WITH_PIPENV) python setup.py sdist --dist-dir $(PYTHON_DIST_DIR)
 
+	$(WITH_PIPENV) pip install -q --disable-pip-version-check wheel
+	$(WITH_PIPENV) python setup.py bdist_wheel --dist-dir $(PYTHON_DIST_DIR)
+
 .PHONY: python/distif
 python/distif:
 	test -f $(PYTHON_DIST_DIR)/*.tar.gz || $(MAKE) python/dist

--- a/modules/python/Makefile.dist
+++ b/modules/python/Makefile.dist
@@ -1,8 +1,8 @@
-PYTHON_DIST_DIR=dist
+PYTHON_DIST_DIR?=dist
 
 .PHONY: python/dist
 python/dist: pipenv setup.py pipenv/generate_requirements
-	$(WITH_PIPENV) python setup.py sdist
+	$(WITH_PIPENV) python setup.py sdist --dist-dir $(PYTHON_DIST_DIR)
 
 .PHONY: python/distif
 python/distif:

--- a/modules/python/Makefile.dist
+++ b/modules/python/Makefile.dist
@@ -1,7 +1,7 @@
 PYTHON_DIST_DIR?=dist
 
 .PHONY: python/dist
-python/dist: pipenv setup.py pipenv/generate_requirements
+python/dist: pipenv setup.py requirements.txt requirements-dev.txt
 	$(WITH_PIPENV) python setup.py sdist --dist-dir $(PYTHON_DIST_DIR)
 
 	$(WITH_PIPENV) pip install -q --disable-pip-version-check wheel

--- a/modules/python/Makefile.dist
+++ b/modules/python/Makefile.dist
@@ -1,12 +1,21 @@
 PYTHON_DIST_DIR?=dist
 
 .PHONY: python/dist
-python/dist: pipenv setup.py requirements.txt requirements-dev.txt
+## Build Python package source and wheel distributions.
+python/dist: python/dist/src python/dist/wheel
+
+.PHONY: python/dist/src
+## Build Python package source distribution.
+python/dist/src: pipenv setup.py requirements.txt requirements-dev.txt
 	$(WITH_PIPENV) python setup.py sdist --dist-dir $(PYTHON_DIST_DIR)
 
+.PHONY: python/dist/wheel
+## Build Python package wheel distributions.
+python/dist/wheel: pipenv setup.py requirements.txt requirements-dev.txt
 	$(WITH_PIPENV) pip install -q --disable-pip-version-check wheel
 	$(WITH_PIPENV) python setup.py bdist_wheel --dist-dir $(PYTHON_DIST_DIR)
 
 .PHONY: python/distif
+## Build Python package source and wheel distributions if they don't exist.
 python/distif:
-	test -f $(PYTHON_DIST_DIR)/*.tar.gz || $(MAKE) python/dist
+	( ls -1qA $(PYTHON_DIST_DIR) 2>/dev/null | grep -q . ) || $(MAKE) python/dist

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -29,6 +29,22 @@ ifneq ($(PY_PIPENV),)
 	endif
 endif
 
+.PHONY: pipenv/check
+## Test that pipenv is in PATH.
+pipenv/check: python/check
+	$(call assert-set,PY_PIPENV)
+	echo "Found pipenv: $(PY_PIPENV)"
+
+.PHONY: pipenv/debug
+## Print build-harness vars about pipenv.
+pipenv/debug: python/debug
+	$(call print-var,PY_PIPENV)
+	$(call print-var,WORKON_HOME)
+	$(call print-var,PIPENV)
+	$(call print-var,PIPENV_PIPFILE_DIR)
+	$(call print-var,PY_VENV)
+	$(call print-var,PIPENV_RUN)
+
 $(PIPENV_PIPFILE_DIR)/Pipfile.lock: $(PIPENV_PIPFILE_DIR)/Pipfile
 	$(call assert-set,PIPENV_PIPFILE_DIR)
 	@$(MAKE) pipenv/lock
@@ -41,39 +57,25 @@ $(PY_VENV)/bin/activate: $(PIPENV_PIPFILE_DIR)/Pipfile.lock
 
 $(PY_VENV): $(PY_VENV)/bin/activate
 
-.PHONY: pipenv/check
-pipenv/check: python/check
-	$(call assert-set,PY_PIPENV)
-	echo "Found pipenv: $(PY_PIPENV)"
-
-.PHONY: pipenv/debug
-pipenv/debug: python/debug
-	$(call print-var,PY_PIPENV)
-	$(call print-var,WORKON_HOME)
-	$(call print-var,PIPENV)
-	$(call print-var,PIPENV_PIPFILE_DIR)
-	$(call print-var,PY_VENV)
-	$(call print-var,PIPENV_RUN)
-
+.PHONY: pipenv
 ## Install and activate a virtual environment using pipenv
 pipenv: pipenv/check $(PY_VENV)
-.PHONY: pipenv
 
+.PHONY: env
 # XXX: This is way to generic a target name.
 env: pipenv
-.PHONY: env
 
+.PHONY: pipenv/lock
 ## Lock dependencies
 pipenv/lock:
 	$(call assert-set,PIPENV_PIPFILE_DIR)
 	$(PIPENV) lock
-.PHONY: pipenv/lock
 
+.PHONY: pipenv/clean
 ## Remove development virtualenv
 pipenv/clean:
 	$(call assert-set,PIPENV_PIPFILE_DIR)
 	$(PIPENV) --rm || true
-.PHONY: pipenv/clean
 
 .PHONY: pipenv/generate_requirements
 ## Generate requirements files based on a Pipfile

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -37,7 +37,9 @@ $(PY_VENV)/bin/activate: $(PIPENV_HOME)/Pipfile.lock
 $(PY_VENV): $(PY_VENV)/bin/activate
 
 .PHONY: pipenv/check
-pipenv/check: python/check ; $(call assert-set,PY_PIPENV) && echo "Found pipenv: $(PY_PIPENV)"
+pipenv/check: python/check
+	$(call assert-set,PY_PIPENV)
+	echo "Found pipenv: $(PY_PIPENV)"
 
 .PHONY: pipenv/debug
 pipenv/debug: python/debug

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -11,12 +11,12 @@ ifneq ($(PY_PIPENV),)
 	WITH_PIPENV := $(PIPENV_RUN)
 
 	# Get the directory where the Pipfile is.
-	PIPENV_HOME := $(shell $(PIPENV) --where 2> /dev/null)
+	PIPENV_PIPFILE_DIR := $(shell $(PIPENV) --where 2> /dev/null)
 
-	ifneq ($(PIPENV_HOME),)
+	ifneq ($(PIPENV_PIPFILE_DIR),)
 		ifeq ($(WORKON_HOME),)
 			# Again, assume we're going to create ".venv" next to the Pipfile.
-			PY_VENV := $(PIPENV_HOME)/.venv
+			PY_VENV := $(PIPENV_PIPFILE_DIR)/.venv
 		else
 			# If the venv doesn't exist yet, then this will fail and PY_VENV will be empty
 			PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
@@ -29,12 +29,12 @@ ifneq ($(PY_PIPENV),)
 	endif
 endif
 
-$(PIPENV_HOME)/Pipfile.lock: $(PIPENV_HOME)/Pipfile
-	$(call assert-set,PIPENV_HOME)
+$(PIPENV_PIPFILE_DIR)/Pipfile.lock: $(PIPENV_PIPFILE_DIR)/Pipfile
+	$(call assert-set,PIPENV_PIPFILE_DIR)
 	@$(MAKE) pipenv/lock
 
-$(PY_VENV)/bin/activate: $(PIPENV_HOME)/Pipfile.lock
-	$(call assert-set,PIPENV_HOME)
+$(PY_VENV)/bin/activate: $(PIPENV_PIPFILE_DIR)/Pipfile.lock
+	$(call assert-set,PIPENV_PIPFILE_DIR)
 	$(call assert-set,PY_PIPENV)
 	$(PIPENV) install --dev --deploy
 	touch $(PY_VENV)/bin/activate
@@ -51,12 +51,12 @@ pipenv/debug: python/debug
 	$(call print-var,PY_PIPENV)
 	$(call print-var,WORKON_HOME)
 	$(call print-var,PIPENV)
-	$(call print-var,PIPENV_HOME)
+	$(call print-var,PIPENV_PIPFILE_DIR)
 	$(call print-var,PY_VENV)
 	$(call print-var,PIPENV_RUN)
 
 ## Install and activate a virtual environment using pipenv
-pipenv: pipenv/check $(PY_VENV) $(PIPENV_HOME)/Pipfile.lock
+pipenv: pipenv/check $(PY_VENV) $(PIPENV_PIPFILE_DIR)/Pipfile.lock
 .PHONY: pipenv
 
 # XXX: This is way to generic a target name.
@@ -65,35 +65,35 @@ env: pipenv
 
 ## Lock dependencies
 pipenv/lock:
-	$(call assert-set,PIPENV_HOME)
+	$(call assert-set,PIPENV_PIPFILE_DIR)
 	$(PIPENV) lock
 .PHONY: pipenv/lock
 
 ## Remove development virtualenv
 pipenv/clean:
-	$(call assert-set,PIPENV_HOME)
+	$(call assert-set,PIPENV_PIPFILE_DIR)
 	$(PIPENV) --rm || true
 .PHONY: pipenv/clean
 
 .PHONY: pipenv/generate_requirements
 ## Generate requirements files based on a Pipfile
-pipenv/generate_requirements: $(PIPENV_HOME)/requirements.txt $(PIPENV_HOME)/requirements-dev.txt
+pipenv/generate_requirements: $(PIPENV_PIPFILE_DIR)/requirements.txt $(PIPENV_PIPFILE_DIR)/requirements-dev.txt
 
-$(PIPENV_HOME)/requirements.txt: $(PIPENV_HOME)/Pipfile
-	$(call assert-set,PIPENV_HOME)
+$(PIPENV_PIPFILE_DIR)/requirements.txt: $(PIPENV_PIPFILE_DIR)/Pipfile
+	$(call assert-set,PIPENV_PIPFILE_DIR)
 	@echo "Writing requirements from Pipfile to requirements.txt"
 	@$(PIPENV_RUN) python -c 'from pipenv.project import Project; section = "packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
 
-$(PIPENV_HOME)/requirements-dev.txt: $(PIPENV_HOME)/Pipfile
-	$(call assert-set,PIPENV_HOME)
+$(PIPENV_PIPFILE_DIR)/requirements-dev.txt: $(PIPENV_PIPFILE_DIR)/Pipfile
+	$(call assert-set,PIPENV_PIPFILE_DIR)
 	@echo "Writing dev requirements from Pipfile to requirements-dev.txt"
 	@$(PIPENV_RUN) python -c 'from pipenv.project import Project; section = "dev-packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements-dev.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
 
 # The requirements*.txt files will be next to the Pipfile.
 # If setup.py and Pipfile are in separate directories, create symlinks.
-requirements.txt: $(PIPENV_HOME)/requirements.txt
-	$(call assert-set,PIPENV_HOME)
-	@test -f requirements.txt || ln -sf $(PIPENV_HOME)/requirements.txt requirements.txt
-requirements-dev.txt: $(PIPENV_HOME)/requirements-dev.txt
-	$(call assert-set,PIPENV_HOME)
-	@test -f requirements-dev.txt || ln -sf $(PIPENV_HOME)/requirements-dev.txt requirements-dev.txt
+requirements.txt: $(PIPENV_PIPFILE_DIR)/requirements.txt
+	$(call assert-set,PIPENV_PIPFILE_DIR)
+	@test -f requirements.txt || ln -sf $(PIPENV_PIPFILE_DIR)/requirements.txt requirements.txt
+requirements-dev.txt: $(PIPENV_PIPFILE_DIR)/requirements-dev.txt
+	$(call assert-set,PIPENV_PIPFILE_DIR)
+	@test -f requirements-dev.txt || ln -sf $(PIPENV_PIPFILE_DIR)/requirements-dev.txt requirements-dev.txt

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -1,41 +1,36 @@
 PY_PIPENV := $(shell which pipenv 2>/dev/null)
-PY_PIPFILE_EXISTS:=$(shell echo "$$(test -f Pipfile; echo $$?)")
-
 ifneq ($(PY_PIPENV),)
-	PY_CURRENT_VENV:=$(shell python -c 'from __future__ import print_function; import sys; print(sys.prefix if hasattr(sys, "real_prefix") or (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix) else "", end="")')
-	ifeq ($(PY_CURRENT_VENV),)
-		PY_VENV:=.venv
+	# Unless WORKON_HOME is set, assume we're going to create ".venv" next to the Pipfile.
+	ifeq ($(WORKON_HOME),)
+		PIPENV := PIPENV_VENV_IN_PROJECT=1 $(PY_PIPENV)
 	else
-		PY_VENV:=$(PY_CURRENT_VENV)
+		PIPENV := PIPENV_VENV_IN_PROJECT= WORKON_HOME='$(WORKON_HOME)' $(PY_PIPENV)
 	endif
+	WITH_PIPENV := $(PIPENV) run
 
-	PY_VENV_WORKDIR?=.
+	# Get the directory where the Pipfile is.
+	PIPENV_HOME := $(shell $(PIPENV) --where 2> /dev/null)
 
-	ifeq ($(PY_PIPFILE_EXISTS),0)
-		ifeq ($(PY_VENV_WORKDIR),.)
-			PIPENV:=PIPENV_VENV_IN_PROJECT=1 $(PY_PIPENV)
-		else
-			PIPENV:=PIPENV_VENV_IN_PROJECT= WORKON_HOME='$(shell realpath $(PY_VENV_WORKDIR))' $(PY_PIPENV)
-			# if the venv doesn't exist then this will fail and PY_VENV will be empty
-			PY_VENV:=$(shell $(PIPENV) --venv 2> /dev/null)
-			ifneq ($(.SHELLSTATUS),0)
-				# means pipenv failed, so it doesn't exist yet. Need to cause a make env
-				_:=$(shell $(value PIPENV) install --dev --deploy)
-
-				PY_VENV:=$(shell $(PIPENV) --venv 2> /dev/null)
-			endif
+	ifeq ($(WORKON_HOME),)
+		# Again, assume we're going to create ".venv" next to the Pipfile.
+		PY_VENV := $(PIPENV_HOME)/.venv
+	else
+		# If the venv doesn't exist yet, then this will fail and PY_VENV will be empty
+		PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
+		ifneq ($(.SHELLSTATUS),0)
+			# Create the venv, then check for it's location again.
+			_ := $(shell $(WITH_PIPENV) run bash -c ':')
+			PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
 		endif
-
-		WITH_PIPENV:=$(PIPENV) run
 	endif
 endif
 
-Pipfile.lock:
-	@echo "You need to lock your environment!"
+$(PIPENV_HOME)/Pipfile.lock: $(PIPENV_HOME)/Pipfile
+	@$(MAKE) pipenv/lock
 
-$(PY_VENV)/bin/activate: Pipfile.lock
+$(PY_VENV)/bin/activate: $(PIPENV_HOME)/Pipfile.lock
 	$(PIPENV) install --dev --deploy
-	if [ "$(PY_VENV_WORKDIR)" = "." ]; then touch $(PY_VENV)/bin/activate; fi
+	touch $(PY_VENV)/bin/activate
 
 $(PY_VENV): $(PY_VENV)/bin/activate
 
@@ -45,14 +40,14 @@ pipenv/check: python/check ; $(call assert-set,PY_PIPENV) && echo "Found pipenv:
 .PHONY: pipenv/debug
 pipenv/debug: python/debug
 	$(call print-var,PY_PIPENV)
-	$(call print-var,PY_PIPFILE_EXISTS)
-	$(call print-var,PY_CURRENT_VENV)
-	$(call print-var,PY_VENV)
+	$(call print-var,WORKON_HOME)
 	$(call print-var,PIPENV)
+	$(call print-var,PIPENV_HOME)
+	$(call print-var,PY_VENV)
 	$(call print-var,WITH_PIPENV)
 
 ## Install and activate a virtual environment using pipenv
-pipenv: pipenv/check $(PY_VENV) Pipfile.lock
+pipenv: pipenv/check $(PY_VENV) $(PIPENV_HOME)/Pipfile.lock
 .PHONY: pipenv
 
 env: pipenv

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -56,7 +56,7 @@ pipenv/debug: python/debug
 	$(call print-var,PIPENV_RUN)
 
 ## Install and activate a virtual environment using pipenv
-pipenv: pipenv/check $(PY_VENV) $(PIPENV_PIPFILE_DIR)/Pipfile.lock
+pipenv: pipenv/check $(PY_VENV)
 .PHONY: pipenv
 
 # XXX: This is way to generic a target name.

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -63,10 +63,6 @@ $(PY_VENV): $(PY_VENV)/bin/activate
 ## Install and activate a virtual environment using pipenv
 pipenv: pipenv/check $(PY_VENV)
 
-.PHONY: env
-# XXX: This is way to generic a target name.
-env: pipenv
-
 .PHONY: pipenv/lock
 ## Lock dependencies
 pipenv/lock:

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -53,7 +53,6 @@ $(PIPENV_PIPFILE_DIR)/Pipfile.lock: $(PIPENV_PIPFILE_DIR)/Pipfile
 
 $(PY_VENV)/bin/activate: $(PIPENV_PIPFILE_DIR)/Pipfile.lock
 	$(call assert-set,PIPENV_PIPFILE_DIR)
-	$(call assert-set,PY_PIPENV)
 	$(PIPENV) install --dev --deploy
 	touch $(PY_VENV)/bin/activate
 

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -11,16 +11,18 @@ ifneq ($(PY_PIPENV),)
 	# Get the directory where the Pipfile is.
 	PIPENV_HOME := $(shell $(PIPENV) --where 2> /dev/null)
 
-	ifeq ($(WORKON_HOME),)
-		# Again, assume we're going to create ".venv" next to the Pipfile.
-		PY_VENV := $(PIPENV_HOME)/.venv
-	else
-		# If the venv doesn't exist yet, then this will fail and PY_VENV will be empty
-		PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
-		ifneq ($(.SHELLSTATUS),0)
-			# Create the venv, then check for it's location again.
-			_ := $(shell $(WITH_PIPENV) install --dev --deploy)
+	ifneq ($(PIPENV_HOME),)
+		ifeq ($(WORKON_HOME),)
+			# Again, assume we're going to create ".venv" next to the Pipfile.
+			PY_VENV := $(PIPENV_HOME)/.venv
+		else
+			# If the venv doesn't exist yet, then this will fail and PY_VENV will be empty
 			PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
+			ifneq ($(.SHELLSTATUS),0)
+				# Create the venv, then check for it's location again.
+				_ := $(shell $(WITH_PIPENV) install --dev --deploy)
+				PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
+			endif
 		endif
 	endif
 endif

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -54,6 +54,7 @@ pipenv/debug: python/debug
 pipenv: pipenv/check $(PY_VENV) $(PIPENV_HOME)/Pipfile.lock
 .PHONY: pipenv
 
+# XXX: This is way to generic a target name.
 env: pipenv
 .PHONY: env
 

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -14,13 +14,15 @@ ifneq ($(PY_PIPENV),)
 	PIPENV_PIPFILE_DIR := $(shell $(PIPENV) --where 2> /dev/null)
 
 	ifneq ($(PIPENV_PIPFILE_DIR),)
-		ifeq ($(WORKON_HOME),)
-			# Again, assume we're going to create ".venv" next to the Pipfile.
-			PY_VENV := $(PIPENV_PIPFILE_DIR)/.venv
-		else
-			# If the venv doesn't exist yet, then this will fail and PY_VENV will be empty
-			PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
-			ifneq ($(.SHELLSTATUS),0)
+		# Check if the venv exists yet.
+		PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
+		
+		ifneq ($(.SHELLSTATUS),0)
+			# The venv doesn't exist yet.
+			ifeq ($(WORKON_HOME),)
+				# Again, assume we're going to create ".venv" next to the Pipfile.
+				PY_VENV := $(PIPENV_PIPFILE_DIR)/.venv
+			else
 				# Create the venv, then check for it's location again.
 				_ := $(shell $(PIPENV_RUN) install --dev --deploy)
 				PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -19,7 +19,7 @@ ifneq ($(PY_PIPENV),)
 		PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
 		ifneq ($(.SHELLSTATUS),0)
 			# Create the venv, then check for it's location again.
-			_ := $(shell $(WITH_PIPENV) run bash -c ':')
+			_ := $(shell $(WITH_PIPENV) install --dev --deploy)
 			PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
 		endif
 	endif

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -63,9 +63,19 @@ pipenv/clean:
 	$(PIPENV) --rm || true
 .PHONY: pipenv/clean
 
-## Generate requirements files based on a Pipfile
-pipenv/generate_requirements:
-	@echo "Writing requirements from Pipfile to requirements.txt and requirements-dev.txt..."
-	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements.txt", mode="w"); [fd.write((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n") for r in reqs.keys()]; fd.close()'
-	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "dev-packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements-dev.txt", mode="w"); [fd.write((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n") for r in reqs.keys()]; fd.close()'
 .PHONY: pipenv/generate_requirements
+## Generate requirements files based on a Pipfile
+pipenv/generate_requirements: $(PIPENV_HOME)/requirements.txt $(PIPENV_HOME)/requirements-dev.txt
+$(PIPENV_HOME)/requirements.txt: $(PIPENV_HOME)/Pipfile
+	@echo "Writing requirements from Pipfile to requirements.txt"
+	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
+$(PIPENV_HOME)/requirements-dev.txt: $(PIPENV_HOME)/Pipfile
+	@echo "Writing dev requirements from Pipfile to requirements-dev.txt"
+	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "dev-packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements-dev.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
+
+# The requirements*.txt files will be next to the Pipfile.
+# If setup.py and Pipfile are in separate directories, create symlinks.
+requirements.txt: $(PIPENV_HOME)/requirements.txt
+	@test -f requirements.txt || ln -sf $(PIPENV_HOME)/requirements.txt requirements.txt
+requirements-dev.txt: $(PIPENV_HOME)/requirements-dev.txt
+	@test -f requirements-dev.txt || ln -sf $(PIPENV_HOME)/requirements-dev.txt requirements-dev.txt

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -28,9 +28,12 @@ ifneq ($(PY_PIPENV),)
 endif
 
 $(PIPENV_HOME)/Pipfile.lock: $(PIPENV_HOME)/Pipfile
+	$(call assert-set,PIPENV_HOME)
 	@$(MAKE) pipenv/lock
 
 $(PY_VENV)/bin/activate: $(PIPENV_HOME)/Pipfile.lock
+	$(call assert-set,PIPENV_HOME)
+	$(call assert-set,PY_PIPENV)
 	$(PIPENV) install --dev --deploy
 	touch $(PY_VENV)/bin/activate
 
@@ -60,27 +63,35 @@ env: pipenv
 
 ## Lock dependencies
 pipenv/lock:
+	$(call assert-set,PIPENV_HOME)
 	$(PIPENV) lock
 .PHONY: pipenv/lock
 
 ## Remove development virtualenv
 pipenv/clean:
+	$(call assert-set,PIPENV_HOME)
 	$(PIPENV) --rm || true
 .PHONY: pipenv/clean
 
 .PHONY: pipenv/generate_requirements
 ## Generate requirements files based on a Pipfile
 pipenv/generate_requirements: $(PIPENV_HOME)/requirements.txt $(PIPENV_HOME)/requirements-dev.txt
+
 $(PIPENV_HOME)/requirements.txt: $(PIPENV_HOME)/Pipfile
+	$(call assert-set,PIPENV_HOME)
 	@echo "Writing requirements from Pipfile to requirements.txt"
 	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
+
 $(PIPENV_HOME)/requirements-dev.txt: $(PIPENV_HOME)/Pipfile
+	$(call assert-set,PIPENV_HOME)
 	@echo "Writing dev requirements from Pipfile to requirements-dev.txt"
 	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "dev-packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements-dev.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
 
 # The requirements*.txt files will be next to the Pipfile.
 # If setup.py and Pipfile are in separate directories, create symlinks.
 requirements.txt: $(PIPENV_HOME)/requirements.txt
+	$(call assert-set,PIPENV_HOME)
 	@test -f requirements.txt || ln -sf $(PIPENV_HOME)/requirements.txt requirements.txt
 requirements-dev.txt: $(PIPENV_HOME)/requirements-dev.txt
+	$(call assert-set,PIPENV_HOME)
 	@test -f requirements-dev.txt || ln -sf $(PIPENV_HOME)/requirements-dev.txt requirements-dev.txt

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -6,7 +6,9 @@ ifneq ($(PY_PIPENV),)
 	else
 		PIPENV := PIPENV_VENV_IN_PROJECT= WORKON_HOME='$(WORKON_HOME)' $(PY_PIPENV)
 	endif
-	WITH_PIPENV := $(PIPENV) run
+	PIPENV_RUN := $(PIPENV) run
+	# Backwards compatible alias.
+	WITH_PIPENV := $(PIPENV_RUN)
 
 	# Get the directory where the Pipfile is.
 	PIPENV_HOME := $(shell $(PIPENV) --where 2> /dev/null)
@@ -20,7 +22,7 @@ ifneq ($(PY_PIPENV),)
 			PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
 			ifneq ($(.SHELLSTATUS),0)
 				# Create the venv, then check for it's location again.
-				_ := $(shell $(WITH_PIPENV) install --dev --deploy)
+				_ := $(shell $(PIPENV_RUN) install --dev --deploy)
 				PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
 			endif
 		endif
@@ -51,7 +53,7 @@ pipenv/debug: python/debug
 	$(call print-var,PIPENV)
 	$(call print-var,PIPENV_HOME)
 	$(call print-var,PY_VENV)
-	$(call print-var,WITH_PIPENV)
+	$(call print-var,PIPENV_RUN)
 
 ## Install and activate a virtual environment using pipenv
 pipenv: pipenv/check $(PY_VENV) $(PIPENV_HOME)/Pipfile.lock
@@ -80,12 +82,12 @@ pipenv/generate_requirements: $(PIPENV_HOME)/requirements.txt $(PIPENV_HOME)/req
 $(PIPENV_HOME)/requirements.txt: $(PIPENV_HOME)/Pipfile
 	$(call assert-set,PIPENV_HOME)
 	@echo "Writing requirements from Pipfile to requirements.txt"
-	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
+	@$(PIPENV_RUN) python -c 'from pipenv.project import Project; section = "packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
 
 $(PIPENV_HOME)/requirements-dev.txt: $(PIPENV_HOME)/Pipfile
 	$(call assert-set,PIPENV_HOME)
 	@echo "Writing dev requirements from Pipfile to requirements-dev.txt"
-	@$(WITH_PIPENV) python -c 'from pipenv.project import Project; section = "dev-packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements-dev.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
+	@$(PIPENV_RUN) python -c 'from pipenv.project import Project; section = "dev-packages"; reqs = {package: (ver["version"] if isinstance(ver, dict) else ver) for package, ver in Project().parsed_pipfile[section].items()}; fd = open("requirements-dev.txt", mode="w"); fd.writelines((r if reqs[r] == "*" else "{} {}".format(r, reqs[r])) + "\n" for r in reqs.keys()); fd.close()'
 
 # The requirements*.txt files will be next to the Pipfile.
 # If setup.py and Pipfile are in separate directories, create symlinks.

--- a/modules/python/Makefile.env
+++ b/modules/python/Makefile.env
@@ -16,7 +16,7 @@ ifneq ($(PY_PIPENV),)
 	ifneq ($(PIPENV_PIPFILE_DIR),)
 		# Check if the venv exists yet.
 		PY_VENV := $(shell $(PIPENV) --venv 2> /dev/null)
-		
+
 		ifneq ($(.SHELLSTATUS),0)
 			# The venv doesn't exist yet.
 			ifeq ($(WORKON_HOME),)
@@ -35,7 +35,7 @@ endif
 ## Test that pipenv is in PATH.
 pipenv/check: python/check
 	$(call assert-set,PY_PIPENV)
-	echo "Found pipenv: $(PY_PIPENV)"
+	@echo "Found pipenv: $(PY_PIPENV)"
 
 .PHONY: pipenv/debug
 ## Print build-harness vars about pipenv.


### PR DESCRIPTION
This PR:

* Refactors the Makefile venv handling logic to be simpler, by leveraging pipenv more to populate path variables.
* Runs `pipenv lock` when the `Pipfile` is newer than `Pipfile.lock`.
* Makes `PYTHON_DIST_DIR` configurable.
* Refactors `python/dist` to handle the case when `setup.py` and `Pipfile` are in separate directories by creating symlinks. `requirement*.txt` files are now only generated if `Pipfile` changes.
* Also builds wheels as part of `python/dist`.