### PR TITLE
If pipenv is in path, install requirements with pipenv to avoid version incompatabilities

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -1,6 +1,8 @@
 BUILD_HARNESS_REQ_TEMPLATE:=$(BUILD_HARNESS_PATH)/requirements.template
 BUILD_HARNESS_REQ_NAME:=.build-harness.requirements.txt
 BUILD_HARNESS_REQ:=$(CURDIR)/$(BUILD_HARNESS_REQ_NAME)
+BUILD_HARNESS_PIPFILE_NAME:=.build-harness.Pipfile
+BUILD_HARNESS_PIPFILE:=$(CURDIR)/$(BUILD_HARNESS_PIPFILE_NAME)
 BUILD_HARNESS_VENV_NAME:=.build-harness.venv
 BUILD_HARNESS_VENV:=$(CURDIR)/$(BUILD_HARNESS_VENV_NAME)
 WITH_BH_VENV=$(shell test -f $(BUILD_HARNESS_REQ) && echo "source $(BUILD_HARNESS_VENV)/bin/activate 2>/dev/null &&")
@@ -26,10 +28,25 @@ $(BUILD_HARNESS_REQ): $(BUILD_HARNESS_REQ_TEMPLATE)
 	@if [ -f $@ ]; then echo "Removing previously generated build-harness requirements" && rm $@; fi
 	@cat $(BUILD_HARNESS_REQ_TEMPLATE) | xargs -I % bash -c 'if [ -z "$$(which % 2>/dev/null)" ]; then echo "% not found" && echo "%" >> $@; fi'
 
-$(BUILD_HARNESS_VENV): $(BUILD_HARNESS_REQ)
+$(BUILD_HARNESS_PIPFILE): $(BUILD_HARNESS_REQ)
+	@if [ -f $@ ]; then echo "Removing previously generated build-harness Pipfile" && rm $@; fi
+	@if [ -n "$$(which pipenv 2>/dev/null)" ]; then \
+		echo "[packages]" >> $@; \
+		cat $(BUILD_HARNESS_REQ) | xargs -I % bash -c 'if [ -z "$$(which % 2>/dev/null)" ]; then echo "% = \"*\"" >> $@; fi'; \
+	fi
+
+$(BUILD_HARNESS_VENV): $(BUILD_HARNESS_REQ) $(BUILD_HARNESS_PIPFILE)
 	@if [ -s $(BUILD_HARNESS_REQ) ]; then echo "Installing: $$(cat $(BUILD_HARNESS_REQ) | tr '\n' ' ')"; fi
-	@test -f $(BUILD_HARNESS_REQ) \
-		&& ( \
+	@if [ -n "$$(which pipenv 2>/dev/null)" ]; then \
+		echo "Installing build-harness requirements with pipenv..."; \
+		( \
+			$(shell if [ $$(python -c 'import platform; ver=int(platform.python_version()[0]); print(ver)' 2>/dev/null) -eq 2 ] && [ -n "$$(which python3 2>/dev/null)" ]; then echo "python3"; else echo "python"; fi) -m venv $@ \
+			&& source $@/bin/activate && pip install -r <(PIPENV_PIPFILE=$(BUILD_HARNESS_PIPFILE) PIPENV_QUIET=1 pipenv --bare lock -r --pre) --ignore-installed \
+		); if [ $$? -ne 0 ]; then rm -rf $@; fi; \
+	else \
+		echo "WARNING: Installing build-harness requirements with venv + pip because pipenv was not installed..."; \
+		( \
 			$(shell if [ $$(python -c 'import platform; ver=int(platform.python_version()[0]); print(ver)' 2>/dev/null) -eq 2 ] && [ -n "$$(which python3 2>/dev/null)" ]; then echo "python3"; else echo "python"; fi) -m venv $@ \
 			&& source $@/bin/activate && pip install -r $(BUILD_HARNESS_REQ) --ignore-installed \
-		); if [ $$? -ne 0 ]; then rm -rf $@; fi
+		); if [ $$? -ne 0 ]; then rm -rf $@; fi; \
+	fi

--- a/modules/python/Makefile.style
+++ b/modules/python/Makefile.style
@@ -27,7 +27,7 @@ python/lint/announce/%:
 .PHONY: python/lint
 ## Check python files using black
 python/lint: bh/venv reports/
-	@$(MAKE) python/lint/targets python/isort/check python/black/check python/flake8 # python/autoflake/check
+	@$(MAKE) python/lint/targets python/isort/check python/black/check python/flake8 python/autoflake/check
 	@echo "Done."
 
 .PHONY: python/autoflake/check
@@ -78,4 +78,4 @@ python/flake8: bh/venv
 
 .PHONY: python/fmt
 ## Format python files
-python/fmt: python/isort python/black # python/autoflake
+python/fmt: python/isort python/black python/autoflake

--- a/requirements.template
+++ b/requirements.template
@@ -2,3 +2,5 @@ advbumpversion
 black
 flake8
 isort
+autoflake
+docker-compose

--- a/requirements.template
+++ b/requirements.template
@@ -3,4 +3,3 @@ black
 flake8
 isort
 autoflake
-docker-compose

--- a/requirements.template
+++ b/requirements.template
@@ -3,3 +3,4 @@ black
 flake8
 isort
 autoflake
+docker-compose


### PR DESCRIPTION
This also
1. re-adds autoflake and re-enables python/autoflake targets for linting and formatting
2. adds docker-compose, because some developers are installing it with pip instead of downloading the binary, so this will do it automatically if anyone doesn't have docker-compose on their path