### PR TITLE
dont fail on missing pyproject.toml

### DIFF
--- a/modules/faas/Makefile
+++ b/modules/faas/Makefile
@@ -37,7 +37,7 @@ faas/build/python/venv:
 faas/build/python/zip:
 	cd $(FAAS_BUILD_PYTHON_VENV) && zip $(FAAS_BUILD_DIST)/build.zip -rq *
 	cd func && zip $(FAAS_BUILD_DIST)/build.zip -r *py
-	cd $(FAAS_BUILD_DIST) && zip build.zip pyproject.toml
+	cd $(FAAS_BUILD_DIST) && (zip build.zip pyproject.toml || true)
 	touch -d "$(FAAS_MAGIC_DATE)" $(FAAS_BUILD_DIST)/build.zip
 
 .PHONY: faas/build/python


### PR DESCRIPTION
## Context
`faas/build/python/zip` assumes that the user has run `faas/build/python/pyproject-toml` beforehand, either directly or through the convenience target `faas/build/python`. 

For projects which don't need/use a pyproject.toml file, `faas/build/python/zip` should continue anyway, ignoring the missing pyproject.toml.

Resolves issue #71