### PR TITLE
Adjusting clean command to handle directories that end in '*egg'.

### DIFF
--- a/modules/python/Makefile
+++ b/modules/python/Makefile
@@ -24,7 +24,7 @@ python/clean/pyc:
 python/clean/dist:
 	rm -fr build/ dist/ .eggs/ requirements*.txt
 	find . -name '*.egg-info' -exec rm -fr {} +
-	find . -name '*.egg' -exec rm -f {} +
+	find . -name '*.egg' -exec rm -fr {} +
 .PHONY: python/clean/dist
 
 python/clean/docs:


### PR DESCRIPTION
Adjusting clean command to handle directories that end in '*egg', instead of just files.

Previous behavior raised error when finding '*egg' directories, causing failed Jenkins builds.